### PR TITLE
Remove slick from requirejs-config

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -25,7 +25,6 @@ var config = {
             'smile-geocoder-provider-google' : 'Smile_Map/js/geocoder-provider/google',
             'listItemEvent'                  : 'Smile_Map/js/listItemEvent',
             'mapMobile'                      : 'Smile_Map/js/mapMobile',
-            'slick'                          : 'Smile_Map/js/lib/slick.min',
             'promotionSlider'                : 'Smile_Map/js/promotionSlider'
         }
     },


### PR DESCRIPTION
This file does not exist and causes an error when integrating a slider with page builder.