### PR TITLE
Add default countrycodes config for osm

### DIFF
--- a/view/frontend/web/js/geocoder-provider/osm.js
+++ b/view/frontend/web/js/geocoder-provider/osm.js
@@ -6,11 +6,14 @@ define([
 
     const BASE_API_URL = '//nominatim.openstreetmap.org';
 
-    function getServiceUrl(qry) {
+    function getServiceUrl(qry, options) {
+        options['countrycodes'] = options['countrycodes'] || 'FR';
         var parameters = L.Util.extend({
             q: qry,
-            format: 'json'
-        }, this.options);
+            format: 'json',
+        }, options);
+
+        this.options = options;
 
         return 'https:'
             + '//nominatim.openstreetmap.org/search'
@@ -39,7 +42,7 @@ define([
      * @param callback  potential callback to call on results
      */
     Geocoder.prototype.geocode = function (queryText, options, callback) {
-        var queryUrl = getServiceUrl(queryText);
+        var queryUrl = getServiceUrl(queryText, options);
         $.getJSON(queryUrl, function(results) {
             results = results.map(this.prepareResult);
             callback(results);


### PR DESCRIPTION
Hey

As mentionned in this issue #19 , we wanted to force search results in specific country. 
In this PR, we just add the parameter countrycodes in config with a default value, like it's done in with google provider.

However we don't see how geocoder would get this config object filled from backend as it would surely be great to have these values chosen by the admin.

Feel free if you have an idea !