### PR TITLE
Add missing declaration of $countryCollection class property

### DIFF
--- a/Model/CountryInformationAcquirer.php
+++ b/Model/CountryInformationAcquirer.php
@@ -25,6 +25,11 @@ use Magento\Framework\Exception\NoSuchEntityException;
 class CountryInformationAcquirer extends \Magento\Directory\Model\CountryInformationAcquirer
 {
     /**
+     * @var \Magento\Directory\Model\ResourceModel\Country\Collection
+     */
+    private $countryCollection;
+
+    /**
      * CountryInformationAcquirer constructor.
      *
      * @param \Magento\Directory\Model\Data\CountryInformationFactory   $countryInformationFactory


### PR DESCRIPTION
Without, PHP 8.2 throws the following exception:

```
Deprecated Functionality: Creation of dynamic property Smile\\Map\\Model\\CountryInformationAcquirer::$countryCollection is deprecated in vendor/smile/module-map/Model/CountryInformationAcquirer.php on line 45
```

See also https://github.com/Smile-SA/magento2-module-store-locator/pull/152