### PR TITLE
Fix compatibility 2 4 6

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/.github export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/CHANGELOG.md export-ignore
+/phpcs.xml.dist export-ignore
+/phpmd.xml.dist export-ignore
+/phpstan.neon.dist export-ignore
+/README.md export-ignore

--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -1,0 +1,66 @@
+name: 'Static Analysis'
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  static-analysis:
+    runs-on: 'ubuntu-latest'
+
+    strategy:
+      matrix:
+        php-version:
+          - '8.1'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v3'
+
+      - name: 'Install PHP'
+        uses: 'shivammathur/setup-php@v2'
+        with:
+          php-version: '${{ matrix.php-version }}'
+          coverage: 'none'
+          tools: 'composer:v2'
+        env:
+          COMPOSER_AUTH_JSON: |
+            {
+                "http-basic": {
+                    "repo.magento.com": {
+                        "username": "${{ secrets.MAGENTO_USERNAME }}",
+                        "password": "${{ secrets.MAGENTO_PASSWORD }}"
+                    }
+                }
+            }
+
+      - name: 'Get composer cache directory'
+        id: 'composer-cache'
+        run: 'echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT'
+
+      - name: 'Cache dependencies'
+        uses: 'actions/cache@v3'
+        with:
+          path: '${{ steps.composer-cache.outputs.dir }}'
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: '${{ runner.os }}-composer-'
+
+      - name: 'Install dependencies'
+        run: 'composer install --prefer-dist'
+
+      - name: 'Run composer audit'
+        run: 'composer audit --format=plain'
+
+      - name: 'Run Parallel Lint'
+        run: 'vendor/bin/parallel-lint --exclude vendor .'
+
+      - name: 'Run PHP CodeSniffer'
+        run: 'vendor/bin/phpcs --extensions=php,phtml'
+
+      - name: 'Run PHPMD'
+        run: 'vendor/bin/phpmd . xml phpmd.xml.dist'
+
+      - name: 'Run PHPStan'
+        run: 'vendor/bin/phpstan analyse'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+/.fleet
+/.idea
+/vendor
+/composer.lock
+/phpcs.xml
+/phpstan.neon

--- a/Api/Data/AddressInterface.php
+++ b/Api/Data/AddressInterface.php
@@ -13,6 +13,8 @@
  */
 namespace Smile\Map\Api\Data;
 
+use Magento\Customer\Api\Data\RegionInterface;
+
 /**
  * Address interface definition.
  *
@@ -35,44 +37,44 @@ interface AddressInterface
     /**
      * Get region.
      *
-     * @return \Magento\Customer\Api\Data\RegionInterface|null
+     * @return RegionInterface|null|string
      */
-    public function getRegion();
+    public function getRegion(): RegionInterface|null|string;
 
     /**
      * Get region ID.
      *
      * @return int|null
      */
-    public function getRegionId();
+    public function getRegionId(): int|null;
 
     /**
      * Two-letter country code in ISO_3166-2 format.
      *
      * @return string|null
      */
-    public function getCountryId();
+    public function getCountryId(): string|null;
 
     /**
      * Get street.
      *
      * @return string[]|string|null
      */
-    public function getStreet();
+    public function getStreet(): array|string|null;
 
     /**
      * Get postcode.
      *
      * @return string|null
      */
-    public function getPostcode();
+    public function getPostcode(): string|null;
 
     /**
      * Get city name.
      *
      * @return string|null
      */
-    public function getCity();
+    public function getCity(): string|null;
 
     /**
      * Set country id.
@@ -81,16 +83,16 @@ interface AddressInterface
      *
      * @return $this
      */
-    public function setCountryId($countryId);
+    public function setCountryId(string $countryId): self;
 
     /**
      * Set region.
      *
-     * @param string $region Region.
+     * @param ?string $region Region.
      *
      * @return $this
      */
-    public function setRegion($region = null);
+    public function setRegion(?string $region = null): self;
 
     /**
      * Set region ID.
@@ -99,7 +101,7 @@ interface AddressInterface
      *
      * @return $this
      */
-    public function setRegionId($regionId);
+    public function setRegionId(int $regionId): self;
 
     /**
      * Set street.
@@ -108,7 +110,7 @@ interface AddressInterface
      *
      * @return $this
      */
-    public function setStreet($street);
+    public function setStreet(array|string $street): self;
 
     /**
      * Set postcode.
@@ -117,7 +119,7 @@ interface AddressInterface
      *
      * @return $this
      */
-    public function setPostcode($postcode);
+    public function setPostcode(string $postcode): self;
 
     /**
      * Set city name.
@@ -126,5 +128,5 @@ interface AddressInterface
      *
      * @return $this
      */
-    public function setCity($city);
+    public function setCity(string $city): self;
 }

--- a/Api/Data/AddressInterface.php
+++ b/Api/Data/AddressInterface.php
@@ -83,7 +83,7 @@ interface AddressInterface
      * @param int $regionId Region id.
      * @return $this
      */
-    public function setRegionId(string|int $regionId): self;
+    public function setRegionId(int $regionId): self;
 
     /**
      * Set street.

--- a/Api/Data/AddressInterface.php
+++ b/Api/Data/AddressInterface.php
@@ -1,11 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Api\Data;
 
 use Magento\Customer\Api\Data\RegionInterface;
 
 /**
  * Address interface definition.
+ * Method's return type must be specified using return annotation
  */
 interface AddressInterface
 {
@@ -18,61 +21,91 @@ interface AddressInterface
 
     /**
      * Get region.
+     *
+     * @return RegionInterface|string|null
      */
     public function getRegion(): RegionInterface|string|null;
 
     /**
      * Get region ID.
+     *
+     * @return ?int
      */
     public function getRegionId(): ?int;
 
     /**
      * Two-letter country code in ISO_3166-2 format.
+     *
+     * @return ?string
      */
     public function getCountryId(): ?string;
 
     /**
      * Get street.
+     *
+     * @return array
      */
     public function getStreet(): array;
 
     /**
      * Get postcode.
+     *
+     * @return ?string
      */
     public function getPostcode(): ?string;
 
     /**
      * Get city name.
+     *
+     * @return ?string
      */
     public function getCity(): ?string;
 
     /**
      * Set country id.
+     *
+     * @param string $countryId Country id.
+     * @return $this
      */
     public function setCountryId(string $countryId): self;
 
     /**
      * Set region.
+     *
+     * @param ?string $region Region.
+     * @return $this
      */
     public function setRegion(?string $region = null): self;
 
     /**
      * Set region ID.
+     *
+     * @param int $regionId Region id.
+     * @return $this
      */
-    public function setRegionId(int $regionId): self;
+    public function setRegionId(string|int $regionId): self;
 
     /**
      * Set street.
+     *
+     * @param string[]|string $street Street.
+     * @return $this
      */
     public function setStreet(array|string $street): self;
 
     /**
      * Set postcode.
+     *
+     * @param string $postcode Postcode.
+     * @return $this
      */
     public function setPostcode(string $postcode): self;
 
     /**
      * Set city name.
+     *
+     * @param string $city City name.
+     * @return $this
      */
     public function setCity(string $city): self;
 }

--- a/Api/Data/AddressInterface.php
+++ b/Api/Data/AddressInterface.php
@@ -1,132 +1,78 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Api\Data;
 
 use Magento\Customer\Api\Data\RegionInterface;
 
 /**
  * Address interface definition.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 interface AddressInterface
 {
-    /**#@+
-     * Constants for keys of data array. Identical to the name of the getter in snake case
-     */
-    const STREET     = 'street';
-    const POSTCODE   = 'postcode';
-    const CITY       = 'city';
-    const REGION     = 'region';
-    const REGION_ID  = 'region_id';
-    const COUNTRY_ID = 'country_id';
+    public const STREET = 'street';
+    public const POSTCODE = 'postcode';
+    public const CITY = 'city';
+    public const REGION = 'region';
+    public const REGION_ID = 'region_id';
+    public const COUNTRY_ID = 'country_id';
 
     /**
      * Get region.
-     *
-     * @return RegionInterface|null|string
      */
-    public function getRegion(): RegionInterface|null|string;
+    public function getRegion(): RegionInterface|string|null;
 
     /**
      * Get region ID.
-     *
-     * @return int|null
      */
-    public function getRegionId(): int|null;
+    public function getRegionId(): ?int;
 
     /**
      * Two-letter country code in ISO_3166-2 format.
-     *
-     * @return string|null
      */
-    public function getCountryId(): string|null;
+    public function getCountryId(): ?string;
 
     /**
      * Get street.
-     *
-     * @return string[]|string|null
      */
-    public function getStreet(): array|string|null;
+    public function getStreet(): array;
 
     /**
      * Get postcode.
-     *
-     * @return string|null
      */
-    public function getPostcode(): string|null;
+    public function getPostcode(): ?string;
 
     /**
      * Get city name.
-     *
-     * @return string|null
      */
-    public function getCity(): string|null;
+    public function getCity(): ?string;
 
     /**
      * Set country id.
-     *
-     * @param string $countryId Country id.
-     *
-     * @return $this
      */
     public function setCountryId(string $countryId): self;
 
     /**
      * Set region.
-     *
-     * @param ?string $region Region.
-     *
-     * @return $this
      */
     public function setRegion(?string $region = null): self;
 
     /**
      * Set region ID.
-     *
-     * @param int $regionId Region id.
-     *
-     * @return $this
      */
     public function setRegionId(int $regionId): self;
 
     /**
      * Set street.
-     *
-     * @param string[]|string $street Street.
-     *
-     * @return $this
      */
     public function setStreet(array|string $street): self;
 
     /**
      * Set postcode.
-     *
-     * @param string $postcode Postcode.
-     *
-     * @return $this
      */
     public function setPostcode(string $postcode): self;
 
     /**
      * Set city name.
-     *
-     * @param string $city City name.
-     *
-     * @return $this
      */
     public function setCity(string $city): self;
 }

--- a/Api/Data/GeoPointInterface.php
+++ b/Api/Data/GeoPointInterface.php
@@ -1,33 +1,14 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Api\Data;
 
 /**
  * Geo point interface definition.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 interface GeoPointInterface
 {
-    /**#@+
-     * Constants for keys of data array. Identical to the name of the getter in snake case
-     */
-    const LATITUDE  = 'latitude';
-    const LONGITUDE = 'longitude';
-    /**#@-*/
+    public const LATITUDE = 'latitude';
+    public const LONGITUDE = 'longitude';
 
     /**
      * Geopoint latitude.

--- a/Api/Data/GeoPointInterface.php
+++ b/Api/Data/GeoPointInterface.php
@@ -34,12 +34,12 @@ interface GeoPointInterface
      *
      * @return float
      */
-    public function getLatitude();
+    public function getLatitude(): float;
 
     /**
      * Geopoint longitude.
      *
      * @return float
      */
-    public function getLongitude();
+    public function getLongitude(): float;
 }

--- a/Api/Data/GeoPointInterface.php
+++ b/Api/Data/GeoPointInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Api\Data;
 
 /**

--- a/Api/Data/GeolocalizedAddressInterface.php
+++ b/Api/Data/GeolocalizedAddressInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Api\Data;
 
 /**
@@ -12,14 +14,14 @@ interface GeolocalizedAddressInterface extends AddressInterface
     /**
      * Get address coordinates.
      *
-     * @return GeoPointInterface
+     * @return \Smile\Map\Api\Data\GeoPointInterface
      */
     public function getCoordinates(): GeoPointInterface;
 
     /**
      * Set address coordinates.
      *
-     * @param GeoPointInterface $coordinates Coordinates.
+     * @param \Smile\Map\Api\Data\GeoPointInterface $coordinates Coordinates.
      * @return $this
      */
     public function setCoordinates(GeoPointInterface $coordinates): self;

--- a/Api/Data/GeolocalizedAddressInterface.php
+++ b/Api/Data/GeolocalizedAddressInterface.php
@@ -16,7 +16,7 @@ interface GeolocalizedAddressInterface extends AddressInterface
      *
      * @return \Smile\Map\Api\Data\GeoPointInterface
      */
-    public function getCoordinates(): GeoPointInterface;
+    public function getCoordinates(): ?GeoPointInterface;
 
     /**
      * Set address coordinates.

--- a/Api/Data/GeolocalizedAddressInterface.php
+++ b/Api/Data/GeolocalizedAddressInterface.php
@@ -13,6 +13,8 @@
  */
 namespace Smile\Map\Api\Data;
 
+use Smile\Map\Api\Data\GeoPointInterface;
+
 /**
  * Geolocalized address interface definition.
  *
@@ -31,16 +33,16 @@ interface GeolocalizedAddressInterface extends AddressInterface
     /**
      * Get address coordinates.
      *
-     * @return \Smile\Map\Api\Data\GeoPointInterface
+     * @return GeoPointInterface
      */
-    public function getCoordinates();
+    public function getCoordinates(): GeoPointInterface;
 
     /**
      * Set address coordinates.
      *
-     * @param \Smile\Map\Api\Data\GeoPointInterface $coordinates Coordinates.
+     * @param GeoPointInterface $coordinates Coordinates.
      *
      * @return $this
      */
-    public function setCoordinates(\Smile\Map\Api\Data\GeoPointInterface $coordinates);
+    public function setCoordinates(GeoPointInterface $coordinates): self;
 }

--- a/Api/Data/GeolocalizedAddressInterface.php
+++ b/Api/Data/GeolocalizedAddressInterface.php
@@ -1,34 +1,13 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
-namespace Smile\Map\Api\Data;
 
-use Smile\Map\Api\Data\GeoPointInterface;
+namespace Smile\Map\Api\Data;
 
 /**
  * Geolocalized address interface definition.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 interface GeolocalizedAddressInterface extends AddressInterface
 {
-    /**#@+
-     * Constants for keys of data array. Identical to the name of the getter in snake case
-     */
-    const COORDINATES = 'coordinates';
-    /**#@-*/
+    public const COORDINATES = 'coordinates';
 
     /**
      * Get address coordinates.
@@ -41,7 +20,6 @@ interface GeolocalizedAddressInterface extends AddressInterface
      * Set address coordinates.
      *
      * @param GeoPointInterface $coordinates Coordinates.
-     *
      * @return $this
      */
     public function setCoordinates(GeoPointInterface $coordinates): self;

--- a/Api/MapInterface.php
+++ b/Api/MapInterface.php
@@ -29,21 +29,21 @@ interface MapInterface
      *
      * @return string
      */
-    public function getIdentifier();
+    public function getIdentifier(): string;
 
     /**
      * Returns current map provider name.
      *
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * Return current map configuration.
      *
      * @return array
      */
-    public function getConfig();
+    public function getConfig(): array;
 
     /**
      * Returns the direction URL using the current provider.
@@ -53,5 +53,5 @@ interface MapInterface
      *
      * @return string
      */
-    public function getDirectionUrl(GeoPointInterface $dest, GeoPointInterface $orig = null);
+    public function getDirectionUrl(GeoPointInterface $dest, GeoPointInterface $orig = null): string;
 }

--- a/Api/MapInterface.php
+++ b/Api/MapInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Api;
 
 use Smile\Map\Api\Data\GeoPointInterface;
@@ -33,8 +35,8 @@ interface MapInterface
     /**
      * Returns the direction URL using the current provider.
      *
-     * @param GeoPointInterface $dest Destination for the direction URL.
-     * @param GeoPointInterface $orig Optional origin for the direction URL.
+     * @param \Smile\Map\Api\Data\GeoPointInterface $dest Destination for the direction URL.
+     * @param \Smile\Map\Api\Data\GeoPointInterface $orig Optional origin for the direction URL.
      * @return string
      */
     public function getDirectionUrl(GeoPointInterface $dest, ?GeoPointInterface $orig = null): string;

--- a/Api/MapInterface.php
+++ b/Api/MapInterface.php
@@ -1,26 +1,11 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Api;
 
 use Smile\Map\Api\Data\GeoPointInterface;
 
 /**
  * Map interface definition.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 interface MapInterface
 {
@@ -50,8 +35,7 @@ interface MapInterface
      *
      * @param GeoPointInterface $dest Destination for the direction URL.
      * @param GeoPointInterface $orig Optional origin for the direction URL.
-     *
      * @return string
      */
-    public function getDirectionUrl(GeoPointInterface $dest, GeoPointInterface $orig = null): string;
+    public function getDirectionUrl(GeoPointInterface $dest, ?GeoPointInterface $orig = null): string;
 }

--- a/Api/MapProviderInterface.php
+++ b/Api/MapProviderInterface.php
@@ -1,24 +1,9 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Api;
 
 /**
  * Map provider interface definition.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 interface MapProviderInterface
 {

--- a/Api/MapProviderInterface.php
+++ b/Api/MapProviderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Api;
 
 /**

--- a/Api/MapProviderInterface.php
+++ b/Api/MapProviderInterface.php
@@ -27,5 +27,5 @@ interface MapProviderInterface
      *
      * @return MapInterface
      */
-    public function getMap();
+    public function getMap(): MapInterface;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [2.1.x] - 2023-04-12
+[2.1.x]: https://github.com/Smile-SA/magento2-module-map/compare/2.0.x...2.1.x
+
+Dataset compatibility ES 2.11.x and PHP 8.2
+
+- fix Dynamic type declaration
+- fix Type hinting
+- Replace `Zend_Date` by `DateTime`
+- Remove `MutationObserver` support
+- fix UI Component Retailer Offer editing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [2.1.x] - 2023-04-12
+## [2.1.x] - 2023-04-24
 [2.1.x]: https://github.com/Smile-SA/magento2-module-map/compare/2.0.x...2.1.x
 
 Dataset compatibility ES 2.11.x and PHP 8.2
@@ -12,3 +12,8 @@ Dataset compatibility ES 2.11.x and PHP 8.2
 - Replace `Zend_Date` by `DateTime`
 - Remove `MutationObserver` support
 - fix UI Component Retailer Offer editing
+- Replace `Zend_Validate` by `Laminas\Validator`
+- fix Retailer Grid Column Action
+- fix Retailer Grid Mass Actions
+- fix some translations
+- remove Temando/Shipping Plugin

--- a/Helper/Map.php
+++ b/Helper/Map.php
@@ -13,10 +13,11 @@
 namespace Smile\Map\Helper;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
-use Magento\Framework\Filesystem;
-use \Magento\Framework\Locale\Resolver as LocaleResolver;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Directory\ReadInterface;
+use Magento\Framework\Locale\Resolver as LocaleResolver;
 use Magento\Framework\View\Asset\Repository;
 use Magento\MediaStorage\Helper\File\Storage\Database;
 use Magento\Store\Model\ScopeInterface;
@@ -43,35 +44,35 @@ class Map extends AbstractHelper
     const SHARED_SETTINGS_NAME = 'all';
 
     /**
-     * @var \Magento\Framework\Locale\Resolver
+     * @var LocaleResolver
      */
-    private $localeResolver;
+    private LocaleResolver $localeResolver;
 
     /**
-     * @var \Magento\MediaStorage\Helper\File\Storage\Database
+     * @var Database
      */
-    private $fileStorageHelper;
+    private Database $fileStorageHelper;
 
     /**
-     * @var \Magento\Framework\Filesystem
+     * @var Filesystem
      */
-    private $fileSystem;
+    private Filesystem $fileSystem;
 
     /**
-     * @var \Magento\Framework\Filesystem\Directory\ReadInterface
+     * @var ReadInterface
      */
-    private $mediaDirectory;
+    private ReadInterface $mediaDirectory;
 
     /**
-     * @var \Magento\Framework\View\Asset\Repository
+     * @var Repository
      */
-    private $assetRepository;
+    private Repository $assetRepository;
 
     /**
      * @var StoreManagerInterface
      */
-    protected $storeManager;
-    
+    protected StoreManagerInterface $storeManager;
+
     /**
      * Map constructor.
      *
@@ -95,6 +96,7 @@ class Map extends AbstractHelper
         $this->fileSystem        = $fileSystem;
         $this->assetRepository   = $assetRepository;
         $this->storeManager      = $storeManager;
+        $this->mediaDirectory    = $this->fileSystem->getDirectoryRead(DirectoryList::MEDIA);
         parent::__construct($context);
     }
 
@@ -103,7 +105,7 @@ class Map extends AbstractHelper
      *
      * @return string
      */
-    public function getProviderIdentifier()
+    public function getProviderIdentifier(): string
     {
         return $this->scopeConfig->getValue(self::MAP_CONFIG_XML_PATH . '/provider');
     }
@@ -115,7 +117,7 @@ class Map extends AbstractHelper
      *
      * @return mixed[]
      */
-    public function getProviderConfiguration($providerIdentifier)
+    public function getProviderConfiguration(string $providerIdentifier): array
     {
         $config = [];
 
@@ -128,7 +130,7 @@ class Map extends AbstractHelper
         };
 
         $allConfig = $this->scopeConfig->getValue(self::MAP_CONFIG_XML_PATH, 'store', $this->storeManager->getStore()->getCode());
-        
+
         array_walk($allConfig, $mapKeyFunc);
 
         if (!isset($config['country'])) {
@@ -151,7 +153,7 @@ class Map extends AbstractHelper
      *
      * @return string
      */
-    private function getMarkerIcon($config)
+    private function getMarkerIcon(array $config): string
     {
         $folderName    = MarkerIcon::UPLOAD_DIR;
         $storeLogoPath = isset($config['markerIcon']) ? $config['markerIcon'] : null;
@@ -182,7 +184,7 @@ class Map extends AbstractHelper
      *
      * @return bool
      */
-    private function isFile($filename)
+    private function isFile(string $filename): bool
     {
         if ($this->fileStorageHelper->checkDbUsage() && !$this->getMediaDirectory()->isFile($filename)) {
             $this->fileStorageHelper->saveFileToFilesystem($filename);
@@ -194,14 +196,10 @@ class Map extends AbstractHelper
     /**
      * Get media directory
      *
-     * @return \Magento\Framework\Filesystem\Directory\Read
+     * @return ReadInterface
      */
-    private function getMediaDirectory()
+    private function getMediaDirectory(): ReadInterface
     {
-        if (!$this->mediaDirectory) {
-            $this->mediaDirectory = $this->fileSystem->getDirectoryRead(DirectoryList::MEDIA);
-        }
-
         return $this->mediaDirectory;
     }
 }

--- a/Helper/Map.php
+++ b/Helper/Map.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Helper;
 
 use Magento\Framework\App\Filesystem\DirectoryList;
@@ -101,7 +103,7 @@ class Map extends AbstractHelper
             $params      = ['_secure' => $this->_getRequest()->isSecure()];
             $url         = $this->assetRepository->getUrlWithParams($defaultFile, $params);
         } catch (LocalizedException $e) {
-            $this->_logger->critical($e);
+            $this->_logger->critical($e->getMessage());
             $url = $this->_urlBuilder->getUrl('', ['_direct' => 'core/index/notFound']);
         }
 

--- a/Model/Address.php
+++ b/Model/Address.php
@@ -68,7 +68,7 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * Set retailer id.
      */
-    public function setRetailerId(string|int $retailerId): self
+    public function setRetailerId(int $retailerId): self
     {
         return $this->setData(self::RETAILER_ID_FIELD, $retailerId);
     }
@@ -92,7 +92,7 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * @inheritdoc
      */
-    public function setRegionId(string|int $regionId): self
+    public function setRegionId(int $regionId): self
     {
         return $this->setData(self::REGION_ID, $regionId);
     }

--- a/Model/Address.php
+++ b/Model/Address.php
@@ -13,8 +13,9 @@
  */
 namespace Smile\Map\Model;
 
-use Smile\Map\Api\Data\AddressInterface;
+use Magento\Customer\Api\Data\RegionInterface;
 use Magento\Framework\Model\AbstractModel;
+use Smile\Map\Api\Data\AddressInterface;
 
 /**
  * Default implementation of the AddressInterface.
@@ -25,18 +26,12 @@ use Magento\Framework\Model\AbstractModel;
  */
 class Address extends AbstractModel implements AddressInterface
 {
-    /**
-     * {@inheritDoc}
-     */
-    public function getCountryId()
-    {
-        return $this->getData(self::COUNTRY_ID);
-    }
+    const RETAILER_ID_FIELD = 'retailer_id';
 
     /**
      * {@inheritDoc}
      */
-    public function getRegion()
+    public function getRegion(): RegionInterface|null|string
     {
         return $this->getData(self::REGION);
     }
@@ -44,16 +39,23 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * {@inheritDoc}
      */
-    public function getRegionId()
+    public function getRegionId(): int|null
     {
         return $this->getData(self::REGION_ID);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    public function getCountryId(): string|null
+    {
+        return $this->getData(self::COUNTRY_ID);
+    }
 
     /**
      * {@inheritDoc}
      */
-    public function getStreet()
+    public function getStreet(): array|string|null
     {
         return is_array($this->getData(self::STREET)) ? $this->getData(self::STREET) : [$this->getData(self::STREET)];
     }
@@ -61,7 +63,7 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * {@inheritDoc}
      */
-    public function getPostcode()
+    public function getPostcode(): string|null
     {
         return $this->getData(self::POSTCODE);
     }
@@ -69,23 +71,25 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * {@inheritDoc}
      */
-    public function getCity()
+    public function getCity(): string|null
     {
         return $this->getData(self::CITY);
     }
 
     /**
-     * {@inheritDoc}
+     * @param string|int $retailerId
+     *
+     * @return $this
      */
-    public function setRetailerId($retailerId)
+    public function setRetailerId(string|int $retailerId): self
     {
-        return $this->setData(self::RETAILER_ID, $retailerId);
+        return $this->setData(self::RETAILER_ID_FIELD, $retailerId);
     }
 
     /**
      * {@inheritDoc}
      */
-    public function setCountryId($countryId)
+    public function setCountryId(string $countryId): self
     {
         return $this->setData(self::COUNTRY_ID, $countryId);
     }
@@ -93,7 +97,7 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * {@inheritDoc}
      */
-    public function setRegion($region = null)
+    public function setRegion(?string $region = null): self
     {
         return $this->setData(self::REGION, $region);
     }
@@ -101,7 +105,7 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * {@inheritDoc}
      */
-    public function setRegionId($regionId)
+    public function setRegionId(int $regionId): self
     {
         return $this->setData(self::REGION_ID, $regionId);
     }
@@ -109,7 +113,7 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * {@inheritDoc}
      */
-    public function setStreet($street)
+    public function setStreet(array|string $street): self
     {
         return $this->setData(self::STREET, $street);
     }
@@ -117,7 +121,7 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * {@inheritDoc}
      */
-    public function setPostcode($postcode)
+    public function setPostcode(string $postcode): self
     {
         return $this->setData(self::POSTCODE, $postcode);
     }
@@ -125,7 +129,7 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * {@inheritDoc}
      */
-    public function setCity($city)
+    public function setCity(string $city): self
     {
         return $this->setData(self::CITY, $city);
     }

--- a/Model/Address.php
+++ b/Model/Address.php
@@ -1,16 +1,5 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Model;
 
 use Magento\Customer\Api\Data\RegionInterface;
@@ -19,67 +8,63 @@ use Smile\Map\Api\Data\AddressInterface;
 
 /**
  * Default implementation of the AddressInterface.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 class Address extends AbstractModel implements AddressInterface
 {
-    const RETAILER_ID_FIELD = 'retailer_id';
+    public const RETAILER_ID_FIELD = 'retailer_id';
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
-    public function getRegion(): RegionInterface|null|string
+    public function getRegion(): RegionInterface|string|null
     {
         return $this->getData(self::REGION);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
-    public function getRegionId(): int|null
+    public function getRegionId(): ?int
     {
         return $this->getData(self::REGION_ID);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
-    public function getCountryId(): string|null
+    public function getCountryId(): ?string
     {
         return $this->getData(self::COUNTRY_ID);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
-    public function getStreet(): array|string|null
+    public function getStreet(): array
     {
-        return is_array($this->getData(self::STREET)) ? $this->getData(self::STREET) : [$this->getData(self::STREET)];
+        return is_array($this->getData(self::STREET))
+            ? $this->getData(self::STREET)
+            : [$this->getData(self::STREET)];
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
-    public function getPostcode(): string|null
+    public function getPostcode(): ?string
     {
         return $this->getData(self::POSTCODE);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
-    public function getCity(): string|null
+    public function getCity(): ?string
     {
         return $this->getData(self::CITY);
     }
 
     /**
-     * @param string|int $retailerId
-     *
-     * @return $this
+     * Set retailer id.
      */
     public function setRetailerId(string|int $retailerId): self
     {
@@ -87,7 +72,7 @@ class Address extends AbstractModel implements AddressInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function setCountryId(string $countryId): self
     {
@@ -95,7 +80,7 @@ class Address extends AbstractModel implements AddressInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function setRegion(?string $region = null): self
     {
@@ -103,7 +88,7 @@ class Address extends AbstractModel implements AddressInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function setRegionId(int $regionId): self
     {
@@ -111,7 +96,7 @@ class Address extends AbstractModel implements AddressInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function setStreet(array|string $street): self
     {
@@ -119,7 +104,7 @@ class Address extends AbstractModel implements AddressInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function setPostcode(string $postcode): self
     {
@@ -127,7 +112,7 @@ class Address extends AbstractModel implements AddressInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function setCity(string $city): self
     {

--- a/Model/Address.php
+++ b/Model/Address.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Model;
 
 use Magento\Customer\Api\Data\RegionInterface;
@@ -26,7 +28,7 @@ class Address extends AbstractModel implements AddressInterface
      */
     public function getRegionId(): ?int
     {
-        return $this->getData(self::REGION_ID);
+        return (int) $this->getData(self::REGION_ID);
     }
 
     /**
@@ -90,7 +92,7 @@ class Address extends AbstractModel implements AddressInterface
     /**
      * @inheritdoc
      */
-    public function setRegionId(int $regionId): self
+    public function setRegionId(string|int $regionId): self
     {
         return $this->setData(self::REGION_ID, $regionId);
     }

--- a/Model/AddressFormatter.php
+++ b/Model/AddressFormatter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Model;
 
 use Magento\Directory\Api\CountryInformationAcquirerInterface;
@@ -45,7 +47,7 @@ class AddressFormatter
         ?int $storeId = null
     ): string {
         if ($storeId === null) {
-            $storeId = $this->storeManager->getStore()->getId();
+            $storeId = (int) $this->storeManager->getStore()->getId();
         }
 
         $template  = $this->getAddressTemplate($format, $storeId);

--- a/Model/AddressFormatter.php
+++ b/Model/AddressFormatter.php
@@ -1,21 +1,12 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Model;
 
 use Magento\Directory\Api\CountryInformationAcquirerInterface;
+use Magento\Framework\App\Cache\Type\Config;
 use Magento\Framework\App\CacheInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Filter\FilterManager;
 use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
@@ -23,103 +14,36 @@ use Smile\Map\Api\Data\AddressInterface;
 
 /**
  * Address formatter tool.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 class AddressFormatter
 {
-    /**
-     * @var string
-     */
-    const FORMAT_XML_BASE_XPATH = 'smile_map/address_templates';
+    private const FORMAT_XML_BASE_XPATH = 'smile_map/address_templates';
+    public const FORMAT_TEXT = 'text';
+    public const FORMAT_ONELINE = 'oneline';
+    public const FORMAT_HTML = 'html';
+    public const FORMAT_PDF = 'pdf';
 
-    /**
-     * @var string
-     */
-    const FORMAT_TEXT    = 'text';
-
-    /**
-     * @var string
-     */
-    const FORMAT_ONELINE = 'oneline';
-
-    /**
-     * @var string
-     */
-    const FORMAT_HTML    = 'html';
-
-    /**
-     * @var string
-     */
-    const FORMAT_PDF     = 'pdf';
-
-    /**
-     * @var StoreManagerInterface
-     */
-    private StoreManagerInterface $storeManager;
-
-    /**
-     * @var ScopeConfigInterface
-     */
-    private ScopeConfigInterface $scopeConfig;
-
-    /**
-     * @var CountryInformationAcquirerInterface
-     */
-    private CountryInformationAcquirerInterface $countryInfo;
-
-    /**
-     * @var FilterManager
-     */
-    private FilterManager $filterManager;
-
-    /**
-     * @var CacheInterface
-     */
-    private CacheInterface $cacheInterface;
-
-    /**
-     * @var array
-     */
     private array $localCache = [];
 
-    /**
-     * Constructor.
-     *
-     * @param FilterManager                         $filterManager  Filter manager used to render address templates.
-     * @param StoreManagerInterface                 $storeManager   Store manager.
-     * @param ScopeConfigInterface                  $scopeConfig    Store configuration
-     * @param CountryInformationAcquirerInterface   $countryInfo    Country info.
-     * @param CacheInterface                        $cacheInterface Cache Interface.
-     */
     public function __construct(
-        FilterManager $filterManager,
-        StoreManagerInterface $storeManager,
-        ScopeConfigInterface $scopeConfig,
-        CountryInformationAcquirerInterface $countryInfo,
-        CacheInterface $cacheInterface
+        private FilterManager $filterManager,
+        private StoreManagerInterface $storeManager,
+        private ScopeConfigInterface $scopeConfig,
+        private CountryInformationAcquirerInterface $countryInfo,
+        private CacheInterface $cacheInterface
     ) {
-        $this->filterManager  = $filterManager;
-        $this->storeManager   = $storeManager;
-        $this->scopeConfig    = $scopeConfig;
-        $this->countryInfo    = $countryInfo;
-        $this->cacheInterface = $cacheInterface;
     }
 
     /**
      * Format the address according to a template.
      *
-     * @param AddressInterface $address Address to be formatted.
-     * @param string           $format  Format code.
-     * @param ?int             $storeId Store id.
-     *
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @return string
+     * @throws NoSuchEntityException
      */
-    public function formatAddress(AddressInterface $address, string $format = self::FORMAT_TEXT, ?int $storeId = null): string
-    {
+    public function formatAddress(
+        AddressInterface $address,
+        string $format = self::FORMAT_TEXT,
+        ?int $storeId = null
+    ): string {
         if ($storeId === null) {
             $storeId = $this->storeManager->getStore()->getId();
         }
@@ -133,18 +57,16 @@ class AddressFormatter
     /**
      * Extract variables used into templates.
      *
-     * @param AddressInterface $address Address to be formatted.
-     *
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @return array
+     * @throws NoSuchEntityException
      */
     private function getVariables(AddressInterface $address): array
     {
+        // @phpstan-ignore-next-line
         $variables = $address->getData();
 
         if ($address->getStreet()) {
             foreach ($address->getStreet() as $index => $streetLine) {
-                $index = $index + 1;
+                ++$index;
                 $variables["street{$index}"] = $streetLine;
             }
 
@@ -161,11 +83,6 @@ class AddressFormatter
 
     /**
      * Load template from the configuration.
-     *
-     * @param string $format  Format code.
-     * @param int    $storeId Store id.
-     *
-     * @return string
      */
     private function getAddressTemplate(string $format, int $storeId): string
     {
@@ -179,17 +96,14 @@ class AddressFormatter
      * This is mainly due to the fact that calling CountryInformationAcquirerInterface::getCountryInfo processes a full
      * loading of directory data, without using any cache.
      *
-     * @param string $countryId The Country Id
-     *
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
-     * @return mixed
+     * @throws NoSuchEntityException
      */
     private function getCountryFullName(string $countryId): mixed
     {
         $store = $this->storeManager->getStore();
         $storeLocale = $this->scopeConfig->getValue(
             'general/locale/code',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+            ScopeInterface::SCOPE_STORES,
             $store->getCode()
         );
 
@@ -203,7 +117,7 @@ class AddressFormatter
                 $this->cacheInterface->save(
                     $data,
                     $cacheKey,
-                    [\Magento\Framework\App\Cache\Type\Config::TYPE_IDENTIFIER],
+                    [Config::TYPE_IDENTIFIER],
                     7200
                 );
             }

--- a/Model/AddressFormatter.php
+++ b/Model/AddressFormatter.php
@@ -13,9 +13,13 @@
  */
 namespace Smile\Map\Model;
 
-use Smile\Map\Api\Data\AddressInterface;
-use Magento\Store\Model\ScopeInterface;
+use Magento\Directory\Api\CountryInformationAcquirerInterface;
 use Magento\Framework\App\CacheInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Filter\FilterManager;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\StoreManagerInterface;
+use Smile\Map\Api\Data\AddressInterface;
 
 /**
  * Address formatter tool.
@@ -52,50 +56,50 @@ class AddressFormatter
     const FORMAT_PDF     = 'pdf';
 
     /**
-     * @var \Magento\Store\Model\StoreManagerInterface
+     * @var StoreManagerInterface
      */
-    private $storeManager;
+    private StoreManagerInterface $storeManager;
 
     /**
-     * @var \Magento\Framework\App\Config\ScopeConfigInterface
+     * @var ScopeConfigInterface
      */
-    private $scopeConfig;
+    private ScopeConfigInterface $scopeConfig;
 
     /**
-     * @var \Magento\Directory\Api\CountryInformationAcquirerInterface
+     * @var CountryInformationAcquirerInterface
      */
-    private $countryInfo;
+    private CountryInformationAcquirerInterface $countryInfo;
 
     /**
-     * @var \Magento\Framework\Filter\FilterManager
+     * @var FilterManager
      */
-    private $filterManager;
+    private FilterManager $filterManager;
 
     /**
-     * @var \Magento\Framework\App\CacheInterface
+     * @var CacheInterface
      */
-    private $cacheInterface;
+    private CacheInterface $cacheInterface;
 
     /**
      * @var array
      */
-    private $localCache = [];
+    private array $localCache = [];
 
     /**
      * Constructor.
      *
-     * @param \Magento\Framework\Filter\FilterManager                    $filterManager  Filter manager used to render address templates.
-     * @param \Magento\Store\Model\StoreManagerInterface                 $storeManager   Store manager.
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface         $scopeConfig    Store configuration
-     * @param \Magento\Directory\Api\CountryInformationAcquirerInterface $countryInfo    Country info.
-     * @param \Magento\Framework\App\CacheInterface                      $cacheInterface Cache Interface.
+     * @param FilterManager                         $filterManager  Filter manager used to render address templates.
+     * @param StoreManagerInterface                 $storeManager   Store manager.
+     * @param ScopeConfigInterface                  $scopeConfig    Store configuration
+     * @param CountryInformationAcquirerInterface   $countryInfo    Country info.
+     * @param CacheInterface                        $cacheInterface Cache Interface.
      */
     public function __construct(
-        \Magento\Framework\Filter\FilterManager $filterManager,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Directory\Api\CountryInformationAcquirerInterface $countryInfo,
-        \Magento\Framework\App\CacheInterface $cacheInterface
+        FilterManager $filterManager,
+        StoreManagerInterface $storeManager,
+        ScopeConfigInterface $scopeConfig,
+        CountryInformationAcquirerInterface $countryInfo,
+        CacheInterface $cacheInterface
     ) {
         $this->filterManager  = $filterManager;
         $this->storeManager   = $storeManager;
@@ -109,11 +113,12 @@ class AddressFormatter
      *
      * @param AddressInterface $address Address to be formatted.
      * @param string           $format  Format code.
-     * @param int              $storeId Store id.
+     * @param ?int             $storeId Store id.
      *
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @return string
      */
-    public function formatAddress(AddressInterface $address, $format = self::FORMAT_TEXT, $storeId = null)
+    public function formatAddress(AddressInterface $address, string $format = self::FORMAT_TEXT, ?int $storeId = null): string
     {
         if ($storeId === null) {
             $storeId = $this->storeManager->getStore()->getId();
@@ -130,9 +135,10 @@ class AddressFormatter
      *
      * @param AddressInterface $address Address to be formatted.
      *
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @return array
      */
-    private function getVariables(AddressInterface $address)
+    private function getVariables(AddressInterface $address): array
     {
         $variables = $address->getData();
 
@@ -161,7 +167,7 @@ class AddressFormatter
      *
      * @return string
      */
-    private function getAddressTemplate($format, $storeId)
+    private function getAddressTemplate(string $format, int $storeId): string
     {
         $path = self::FORMAT_XML_BASE_XPATH . '/' . $format;
 
@@ -175,9 +181,10 @@ class AddressFormatter
      *
      * @param string $countryId The Country Id
      *
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @return mixed
      */
-    private function getCountryFullName($countryId)
+    private function getCountryFullName(string $countryId): mixed
     {
         $store = $this->storeManager->getStore();
         $storeLocale = $this->scopeConfig->getValue(

--- a/Model/Config/Backend/MarkerIcon.php
+++ b/Model/Config/Backend/MarkerIcon.php
@@ -1,38 +1,20 @@
 <?php
-/**
- * DISCLAIMER
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Romain Ruaud <romain.ruaud@smile.fr>
- * @copyright 2017 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
+
 namespace Smile\Map\Model\Config\Backend;
 
 use Magento\Config\Model\Config\Backend\File;
 
 /**
  * MarkerIcon backend model. Extended to allow svg files.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Romain Ruaud <romain.ruaud@smile.fr>
  */
 class MarkerIcon extends File
 {
-    /**
-     * Where the files are stored.
-     */
-    const UPLOAD_DIR = 'smile_map/marker';
+    public const UPLOAD_DIR = 'smile_map/marker';
 
     /**
-     * {@inheritdoc}
-     * @SuppressWarnings(PHPMD.CamelCaseMethodName) method is inherited.
+     * @inheritdoc
      */
-    protected function _getAllowedExtensions(): array
+    protected function _getAllowedExtensions()
     {
         return ['jpg', 'jpeg', 'gif', 'png', 'svg'];
     }

--- a/Model/Config/Backend/MarkerIcon.php
+++ b/Model/Config/Backend/MarkerIcon.php
@@ -12,6 +12,8 @@
  */
 namespace Smile\Map\Model\Config\Backend;
 
+use Magento\Config\Model\Config\Backend\File;
+
 /**
  * MarkerIcon backend model. Extended to allow svg files.
  *
@@ -19,7 +21,7 @@ namespace Smile\Map\Model\Config\Backend;
  * @package  Smile\Map
  * @author   Romain Ruaud <romain.ruaud@smile.fr>
  */
-class MarkerIcon extends \Magento\Config\Model\Config\Backend\File
+class MarkerIcon extends File
 {
     /**
      * Where the files are stored.
@@ -30,7 +32,7 @@ class MarkerIcon extends \Magento\Config\Model\Config\Backend\File
      * {@inheritdoc}
      * @SuppressWarnings(PHPMD.CamelCaseMethodName) method is inherited.
      */
-    protected function _getAllowedExtensions()
+    protected function _getAllowedExtensions(): array
     {
         return ['jpg', 'jpeg', 'gif', 'png', 'svg'];
     }

--- a/Model/Config/Backend/MarkerIcon.php
+++ b/Model/Config/Backend/MarkerIcon.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Model\Config\Backend;
 
 use Magento\Config\Model\Config\Backend\File;

--- a/Model/Config/Source/MapProvider.php
+++ b/Model/Config/Source/MapProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Model\Config\Source;
 
 use Magento\Framework\Data\OptionSourceInterface;

--- a/Model/Config/Source/MapProvider.php
+++ b/Model/Config/Source/MapProvider.php
@@ -12,6 +12,9 @@
  */
 namespace Smile\Map\Model\Config\Source;
 
+use Magento\Framework\Data\OptionSourceInterface;
+use Smile\Map\Model\MapProvider as MapProviderModel;
+
 /**
  * Source Model for Map provider in module configuration.
  *
@@ -19,19 +22,19 @@ namespace Smile\Map\Model\Config\Source;
  * @package  Smile\Map
  * @author   Romain Ruaud <romain.ruaud@smile.fr>
  */
-class MapProvider implements \Magento\Framework\Data\OptionSourceInterface
+class MapProvider implements OptionSourceInterface
 {
     /**
-     * @var \Smile\Map\Model\MapProvider
+     * @var MapProviderModel
      */
-    private $mapProvider;
+    private MapProviderModel $mapProvider;
 
     /**
      * MapProvider constructor.
      *
-     * @param \Smile\Map\Model\MapProvider $mapProvider The Map provider
+     * @param MapProviderModel $mapProvider The Map provider
      */
-    public function __construct(\Smile\Map\Model\MapProvider $mapProvider)
+    public function __construct(MapProviderModel $mapProvider)
     {
         $this->mapProvider = $mapProvider;
     }
@@ -41,7 +44,7 @@ class MapProvider implements \Magento\Framework\Data\OptionSourceInterface
      *
      * @return array Format: array(array('value' => '<value>', 'label' => '<label>'), ...)
      */
-    public function toOptionArray()
+    public function toOptionArray(): array
     {
         $result = [];
 

--- a/Model/Config/Source/MapProvider.php
+++ b/Model/Config/Source/MapProvider.php
@@ -1,15 +1,5 @@
 <?php
-/**
- * DISCLAIMER
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Romain Ruaud <romain.ruaud@smile.fr>
- * @copyright 2017 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
+
 namespace Smile\Map\Model\Config\Source;
 
 use Magento\Framework\Data\OptionSourceInterface;
@@ -17,32 +7,15 @@ use Smile\Map\Model\MapProvider as MapProviderModel;
 
 /**
  * Source Model for Map provider in module configuration.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Romain Ruaud <romain.ruaud@smile.fr>
  */
 class MapProvider implements OptionSourceInterface
 {
-    /**
-     * @var MapProviderModel
-     */
-    private MapProviderModel $mapProvider;
-
-    /**
-     * MapProvider constructor.
-     *
-     * @param MapProviderModel $mapProvider The Map provider
-     */
-    public function __construct(MapProviderModel $mapProvider)
+    public function __construct(private MapProviderModel $mapProvider)
     {
-        $this->mapProvider = $mapProvider;
     }
 
     /**
-     * Return array of options as value-label pairs
-     *
-     * @return array Format: array(array('value' => '<value>', 'label' => '<label>'), ...)
+     * @inheritdoc
      */
     public function toOptionArray(): array
     {

--- a/Model/CountryInformationAcquirer.php
+++ b/Model/CountryInformationAcquirer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Model;
 
 use Magento\Directory\Api\Data\CountryInformationInterface;

--- a/Model/CountryInformationAcquirer.php
+++ b/Model/CountryInformationAcquirer.php
@@ -13,7 +13,14 @@
  */
 namespace Smile\Map\Model;
 
+use Magento\Directory\Api\Data\CountryInformationInterface;
+use Magento\Directory\Helper\Data;
+use Magento\Directory\Model\Data\CountryInformationFactory;
+use Magento\Directory\Model\Data\RegionInformationFactory;
+use Magento\Directory\Model\ResourceModel\Country\Collection;
+use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Override default implementation of the Magento CountryInformationAcquirer
@@ -25,22 +32,27 @@ use Magento\Framework\Exception\NoSuchEntityException;
 class CountryInformationAcquirer extends \Magento\Directory\Model\CountryInformationAcquirer
 {
     /**
+     * @var Collection
+     */
+    private Collection $countryCollection;
+
+    /**
      * CountryInformationAcquirer constructor.
      *
-     * @param \Magento\Directory\Model\Data\CountryInformationFactory   $countryInformationFactory
-     * @param \Magento\Directory\Model\Data\RegionInformationFactory    $regionInformationFactory
-     * @param \Magento\Directory\Helper\Data                            $directoryHelper
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface        $scopeConfig
-     * @param \Magento\Store\Model\StoreManagerInterface                $storeManager
-     * @param \Magento\Directory\Model\ResourceModel\Country\Collection $countryCollection
+     * @param CountryInformationFactory $countryInformationFactory
+     * @param RegionInformationFactory  $regionInformationFactory
+     * @param Data                      $directoryHelper
+     * @param ScopeConfigInterface      $scopeConfig
+     * @param StoreManagerInterface     $storeManager
+     * @param Collection                $countryCollection
      */
     public function __construct(
-        \Magento\Directory\Model\Data\CountryInformationFactory $countryInformationFactory,
-        \Magento\Directory\Model\Data\RegionInformationFactory $regionInformationFactory,
-        \Magento\Directory\Helper\Data $directoryHelper,
-        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
-        \Magento\Store\Model\StoreManagerInterface $storeManager,
-        \Magento\Directory\Model\ResourceModel\Country\Collection $countryCollection
+        CountryInformationFactory $countryInformationFactory,
+        RegionInformationFactory $regionInformationFactory,
+        Data $directoryHelper,
+        ScopeConfigInterface $scopeConfig,
+        StoreManagerInterface $storeManager,
+        Collection $countryCollection
     ) {
         $this->countryCollection = $countryCollection;
         parent::__construct($countryInformationFactory, $regionInformationFactory, $directoryHelper, $scopeConfig, $storeManager);
@@ -51,10 +63,10 @@ class CountryInformationAcquirer extends \Magento\Directory\Model\CountryInforma
      *
      * @param string $countryId Country Id
      *
-     * @return \Magento\Directory\Api\Data\CountryInformationInterface
+     * @return CountryInformationInterface
      * @throws NoSuchEntityException
      */
-    public function getCountryInfo($countryId)
+    public function getCountryInfo($countryId): CountryInformationInterface
     {
         $store = $this->storeManager->getStore();
         $storeLocale = $this->scopeConfig->getValue(
@@ -74,8 +86,7 @@ class CountryInformationAcquirer extends \Magento\Directory\Model\CountryInforma
                 )
             );
         }
-        $countryInfo = $this->setCountryInfo($country, $regions, $storeLocale);
 
-        return $countryInfo;
+        return $this->setCountryInfo($country, $regions, $storeLocale);
     }
 }

--- a/Model/CountryInformationAcquirer.php
+++ b/Model/CountryInformationAcquirer.php
@@ -1,16 +1,5 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Maxime Leclercq <maxime.leclercq@smile.fr>
- * @copyright 2018 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Model;
 
 use Magento\Directory\Api\Data\CountryInformationInterface;
@@ -20,71 +9,49 @@ use Magento\Directory\Model\Data\RegionInformationFactory;
 use Magento\Directory\Model\ResourceModel\Country\Collection;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\ScopeInterface;
 use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * Override default implementation of the Magento CountryInformationAcquirer
  * for find country information even if it is not in the list of authorized countries.
- *
- * @category Smile
- * @package  Smile\Map
  */
 class CountryInformationAcquirer extends \Magento\Directory\Model\CountryInformationAcquirer
 {
-    /**
-     * @var Collection
-     */
-    private Collection $countryCollection;
-
-    /**
-     * CountryInformationAcquirer constructor.
-     *
-     * @param CountryInformationFactory $countryInformationFactory
-     * @param RegionInformationFactory  $regionInformationFactory
-     * @param Data                      $directoryHelper
-     * @param ScopeConfigInterface      $scopeConfig
-     * @param StoreManagerInterface     $storeManager
-     * @param Collection                $countryCollection
-     */
     public function __construct(
         CountryInformationFactory $countryInformationFactory,
         RegionInformationFactory $regionInformationFactory,
         Data $directoryHelper,
         ScopeConfigInterface $scopeConfig,
         StoreManagerInterface $storeManager,
-        Collection $countryCollection
+        private Collection $countryCollection
     ) {
-        $this->countryCollection = $countryCollection;
-        parent::__construct($countryInformationFactory, $regionInformationFactory, $directoryHelper, $scopeConfig, $storeManager);
+        parent::__construct(
+            $countryInformationFactory,
+            $regionInformationFactory,
+            $directoryHelper,
+            $scopeConfig,
+            $storeManager
+        );
     }
 
     /**
-     * Get country and region information for the store.
-     *
-     * @param string $countryId Country Id
-     *
-     * @return CountryInformationInterface
-     * @throws NoSuchEntityException
+     * @inheritdoc
      */
     public function getCountryInfo($countryId): CountryInformationInterface
     {
         $store = $this->storeManager->getStore();
         $storeLocale = $this->scopeConfig->getValue(
             'general/locale/code',
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORES,
+            ScopeInterface::SCOPE_STORES,
             $store->getCode()
         );
 
         $countriesCollection = $this->countryCollection->load();
         $regions = $this->directoryHelper->getRegionData();
         $country = $countriesCollection->getItemById($countryId);
-
-        if (!$country || !$country->getId()) {
-            throw new NoSuchEntityException(
-                __(
-                    'Requested country is not available.'
-                )
-            );
+        if (!$country) {
+            throw new NoSuchEntityException(__('Requested country is not available.'));
         }
 
         return $this->setCountryInfo($country, $regions, $storeLocale);

--- a/Model/GeoPoint.php
+++ b/Model/GeoPoint.php
@@ -27,12 +27,12 @@ class GeoPoint implements GeoPointInterface
     /**
      * @var float
      */
-    private $latitude;
+    private float $latitude;
 
     /**
      * @var float
      */
-    private $longitude;
+    private float $longitude;
 
     /**
      * Constructor.
@@ -40,7 +40,7 @@ class GeoPoint implements GeoPointInterface
      * @param float $latitude  Latitude
      * @param float $longitude Longitude
      */
-    public function __construct($latitude, $longitude)
+    public function __construct(float $latitude, float $longitude)
     {
         $this->latitude  = $latitude;
         $this->longitude = $longitude;
@@ -49,7 +49,7 @@ class GeoPoint implements GeoPointInterface
     /**
      * {@inheritDoc}
      */
-    public function getLatitude()
+    public function getLatitude(): float
     {
         return $this->latitude;
     }
@@ -57,7 +57,7 @@ class GeoPoint implements GeoPointInterface
     /**
      * {@inheritDoc}
      */
-    public function getLongitude()
+    public function getLongitude(): float
     {
         return $this->longitude;
     }

--- a/Model/GeoPoint.php
+++ b/Model/GeoPoint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Model;
 
 use Smile\Map\Api\Data\GeoPointInterface;

--- a/Model/GeoPoint.php
+++ b/Model/GeoPoint.php
@@ -1,53 +1,20 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Model;
 
 use Smile\Map\Api\Data\GeoPointInterface;
 
 /**
  * Default implementation of the GeoPointInterface.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 class GeoPoint implements GeoPointInterface
 {
-    /**
-     * @var float
-     */
-    private float $latitude;
-
-    /**
-     * @var float
-     */
-    private float $longitude;
-
-    /**
-     * Constructor.
-     *
-     * @param float $latitude  Latitude
-     * @param float $longitude Longitude
-     */
-    public function __construct(float $latitude, float $longitude)
+    public function __construct(private float $latitude, private float $longitude)
     {
-        $this->latitude  = $latitude;
-        $this->longitude = $longitude;
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function getLatitude(): float
     {
@@ -55,7 +22,7 @@ class GeoPoint implements GeoPointInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function getLongitude(): float
     {

--- a/Model/GeolocalizedAddress.php
+++ b/Model/GeolocalizedAddress.php
@@ -14,6 +14,7 @@
 namespace Smile\Map\Model;
 
 use Smile\Map\Api\Data\GeolocalizedAddressInterface;
+use Smile\Map\Api\Data\GeoPointInterface;
 
 /**
  * Default implementation of the GeolocalizedAddressInterface.
@@ -27,7 +28,7 @@ class GeolocalizedAddress extends Address implements GeolocalizedAddressInterfac
     /**
      * {@inheritDoc}
      */
-    public function getCoordinates()
+    public function getCoordinates(): GeoPointInterface
     {
         return $this->getData(self::COORDINATES);
     }
@@ -35,7 +36,7 @@ class GeolocalizedAddress extends Address implements GeolocalizedAddressInterfac
     /**
      * {@inheritDoc}
      */
-    public function setCoordinates(\Smile\Map\Api\Data\GeoPointInterface $coordinates)
+    public function setCoordinates(GeoPointInterface $coordinates): self
     {
         return $this->setData(self::COORDINATES, $coordinates);
     }

--- a/Model/GeolocalizedAddress.php
+++ b/Model/GeolocalizedAddress.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Model;
 
 use Smile\Map\Api\Data\GeolocalizedAddressInterface;

--- a/Model/GeolocalizedAddress.php
+++ b/Model/GeolocalizedAddress.php
@@ -1,16 +1,5 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Model;
 
 use Smile\Map\Api\Data\GeolocalizedAddressInterface;
@@ -18,15 +7,11 @@ use Smile\Map\Api\Data\GeoPointInterface;
 
 /**
  * Default implementation of the GeolocalizedAddressInterface.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 class GeolocalizedAddress extends Address implements GeolocalizedAddressInterface
 {
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function getCoordinates(): GeoPointInterface
     {
@@ -34,7 +19,7 @@ class GeolocalizedAddress extends Address implements GeolocalizedAddressInterfac
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function setCoordinates(GeoPointInterface $coordinates): self
     {

--- a/Model/Map/DefaultMap.php
+++ b/Model/Map/DefaultMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Model\Map;
 
 use Magento\Framework\DataObject;

--- a/Model/Map/DefaultMap.php
+++ b/Model/Map/DefaultMap.php
@@ -13,9 +13,10 @@
  */
 namespace Smile\Map\Model\Map;
 
-use \Smile\Map\Helper\Map as MapHelper;
 use Magento\Framework\Filter\FilterManager;
 use Smile\Map\Api\Data\GeoPointInterface;
+use Smile\Map\Api\MapInterface;
+use Smile\Map\Helper\Map as MapHelper;
 
 /**
  * Default implementation of the MapInterface.
@@ -24,27 +25,27 @@ use Smile\Map\Api\Data\GeoPointInterface;
  * @package  Smile\Map
  * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
-class DefaultMap implements \Smile\Map\Api\MapInterface
+class DefaultMap implements MapInterface
 {
     /**
      * @var string
      */
-    private $identifier;
+    private string $identifier;
 
     /**
      * @var string
      */
-    private $name;
+    private string $name;
 
     /**
      * @var array
      */
-    private $config;
+    private array $config;
 
     /**
      * @var FilterManager
      */
-    private $filterManager;
+    private FilterManager $filterManager;
 
     /**
      * Constructor.
@@ -54,8 +55,12 @@ class DefaultMap implements \Smile\Map\Api\MapInterface
      * @param MapHelper     $mapHelper     Map helper.
      * @param FilterManager $filterManager Template filter manager.
      */
-    public function __construct($identifier, $name, MapHelper $mapHelper, FilterManager $filterManager)
-    {
+    public function __construct(
+        string $identifier,
+        string $name,
+        MapHelper $mapHelper,
+        FilterManager $filterManager
+    ) {
         $this->identifier    = $identifier;
         $this->name          = $name;
         $this->config        = $mapHelper->getProviderConfiguration($identifier);
@@ -65,7 +70,7 @@ class DefaultMap implements \Smile\Map\Api\MapInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfig()
+    public function getConfig(): array
     {
         return $this->config;
     }
@@ -73,7 +78,7 @@ class DefaultMap implements \Smile\Map\Api\MapInterface
     /**
      * {@inheritDoc}
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -81,7 +86,7 @@ class DefaultMap implements \Smile\Map\Api\MapInterface
     /**
      * {@inheritDoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -89,7 +94,7 @@ class DefaultMap implements \Smile\Map\Api\MapInterface
     /**
      * {@inheritDoc}
      */
-    public function getDirectionUrl(GeoPointInterface $dest, GeoPointInterface $orig = null)
+    public function getDirectionUrl(GeoPointInterface $dest, GeoPointInterface $orig = null): string
     {
         $urlTemplate = $this->config['direction_url_template'];
 

--- a/Model/Map/DefaultMap.php
+++ b/Model/Map/DefaultMap.php
@@ -1,18 +1,8 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Model\Map;
 
+use Magento\Framework\DataObject;
 use Magento\Framework\Filter\FilterManager;
 use Smile\Map\Api\Data\GeoPointInterface;
 use Smile\Map\Api\MapInterface;
@@ -20,55 +10,22 @@ use Smile\Map\Helper\Map as MapHelper;
 
 /**
  * Default implementation of the MapInterface.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 class DefaultMap implements MapInterface
 {
-    /**
-     * @var string
-     */
-    private string $identifier;
-
-    /**
-     * @var string
-     */
-    private string $name;
-
-    /**
-     * @var array
-     */
     private array $config;
 
-    /**
-     * @var FilterManager
-     */
-    private FilterManager $filterManager;
-
-    /**
-     * Constructor.
-     *
-     * @param string        $identifier    Map identifier.
-     * @param string        $name          Map provider name.
-     * @param MapHelper     $mapHelper     Map helper.
-     * @param FilterManager $filterManager Template filter manager.
-     */
     public function __construct(
-        string $identifier,
-        string $name,
+        private string $identifier,
+        private string $name,
         MapHelper $mapHelper,
-        FilterManager $filterManager
+        private FilterManager $filterManager
     ) {
-        $this->identifier    = $identifier;
-        $this->name          = $name;
-        $this->config        = $mapHelper->getProviderConfiguration($identifier);
-        $this->filterManager = $filterManager;
+        $this->config = $mapHelper->getProviderConfiguration($identifier);
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function getConfig(): array
     {
@@ -76,7 +33,7 @@ class DefaultMap implements MapInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function getIdentifier(): string
     {
@@ -84,7 +41,7 @@ class DefaultMap implements MapInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function getName(): string
     {
@@ -92,13 +49,13 @@ class DefaultMap implements MapInterface
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
-    public function getDirectionUrl(GeoPointInterface $dest, GeoPointInterface $orig = null): string
+    public function getDirectionUrl(GeoPointInterface $dest, ?GeoPointInterface $orig = null): string
     {
         $urlTemplate = $this->config['direction_url_template'];
 
-        $data = new \Magento\Framework\DataObject();
+        $data = new DataObject();
 
         $data->setDestLatitude($dest->getLatitude());
         $data->setDestLongitude($dest->getLongitude());

--- a/Model/MapProvider.php
+++ b/Model/MapProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Smile\Map\Model;
 
 use LogicException;

--- a/Model/MapProvider.php
+++ b/Model/MapProvider.php
@@ -13,6 +13,7 @@
  */
 namespace Smile\Map\Model;
 
+use Smile\Map\Api\MapInterface;
 use Smile\Map\Api\MapProviderInterface;
 use Smile\Map\Helper\Map as MapHelper;
 
@@ -26,14 +27,14 @@ use Smile\Map\Helper\Map as MapHelper;
 class MapProvider implements MapProviderInterface
 {
     /**
-     * @var \Smile\Map\Api\MapInterface[]
+     * @var MapInterface[]
      */
-    private $mapProviders;
+    private array $mapProviders;
 
     /**
      * @var MapHelper
      */
-    private $mapHelper;
+    private MapHelper $mapHelper;
 
     /**
      * Contructor.
@@ -41,8 +42,10 @@ class MapProvider implements MapProviderInterface
      * @param MapHelper $mapHelper    Map helper.
      * @param array     $mapProviders Map providers.
      */
-    public function __construct(MapHelper $mapHelper, array $mapProviders = [])
-    {
+    public function __construct(
+        MapHelper $mapHelper,
+        array $mapProviders = []
+    ) {
         $this->mapHelper    = $mapHelper;
         $this->mapProviders = $mapProviders;
     }
@@ -50,7 +53,7 @@ class MapProvider implements MapProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getMap()
+    public function getMap(): MapInterface
     {
         $providerIdentifier = $this->mapHelper->getProviderIdentifier();
 
@@ -62,9 +65,9 @@ class MapProvider implements MapProviderInterface
     }
 
     /**
-     * @return array|\Smile\Map\Api\MapInterface[]
+     * @return array|MapInterface[]
      */
-    public function getProviders()
+    public function getProviders(): array
     {
         return $this->mapProviders;
     }

--- a/Model/MapProvider.php
+++ b/Model/MapProvider.php
@@ -1,71 +1,44 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
+
 namespace Smile\Map\Model;
 
+use LogicException;
 use Smile\Map\Api\MapInterface;
 use Smile\Map\Api\MapProviderInterface;
 use Smile\Map\Helper\Map as MapHelper;
 
 /**
  * Default implementation of the MapProviderInterface.
- *
- * @category Smile
- * @package  Smile\Map
- * @author   Aurelien FOUCRET <aurelien.foucret@smile.fr>
  */
 class MapProvider implements MapProviderInterface
 {
     /**
-     * @var MapInterface[]
-     */
-    private array $mapProviders;
-
-    /**
-     * @var MapHelper
-     */
-    private MapHelper $mapHelper;
-
-    /**
-     * Contructor.
-     *
-     * @param MapHelper $mapHelper    Map helper.
-     * @param array     $mapProviders Map providers.
+     * @param MapInterface[] $mapProviders
      */
     public function __construct(
-        MapHelper $mapHelper,
-        array $mapProviders = []
+        private MapHelper $mapHelper,
+        private array $mapProviders = []
     ) {
-        $this->mapHelper    = $mapHelper;
-        $this->mapProviders = $mapProviders;
     }
 
     /**
-     * {@inheritDoc}
+     * @inheritdoc
      */
     public function getMap(): MapInterface
     {
         $providerIdentifier = $this->mapHelper->getProviderIdentifier();
 
         if (!isset($this->mapProviders[$providerIdentifier])) {
-            throw new \LogicException(__("Map provider %s does not exists", $providerIdentifier));
+            throw new LogicException(__("Map provider %s does not exists", $providerIdentifier));
         }
 
         return $this->mapProviders[$providerIdentifier];
     }
 
     /**
-     * @return array|MapInterface[]
+     * Get map providers.
+     *
+     * @return MapInterface[]
      */
     public function getProviders(): array
     {

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,13 @@
         }
     ],
     "require": {
-        "magento/framework": "*",
+        "php": "^8.1",
+        "magento/framework": ">=103.0.4",
         "magento/module-store": "*",
-        "willdurand/geocoder": "^3.3 || ^4.4"
+        "willdurand/geocoder": "^4.4"
     },
     "require-dev": {
-        "smile/magento2-smilelab-quality-suite": "1.0.0"
+        "smile/magento2-smilelab-quality-suite": "^3.0"
     },
     "license": "OSL-3.0",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -3,44 +3,47 @@
     "type": "magento2-module",
     "description": "Smile Map Utilities Module",
     "keywords": ["magento2", "map", "geocoding", "geolocalisation"],
+    "license": "OSL-3.0",
+    "authors": [
+        {
+            "name": "Aurélien Foucret",
+            "email": "aurelien.foucret@smile.fr"
+        },
+        {
+            "name": "Romain Ruaud",
+            "email": "romain.ruaud@smile.fr"
+        }
+    ],
+    "require": {
+        "php": "^8.1",
+        "magento/framework": ">=103.0.4",
+        "magento/module-store": ">=101.1.4",
+        "willdurand/geocoder": "^4.4"
+    },
+    "require-dev": {
+        "smile/magento2-smilelab-quality-suite": "^3.0"
+    },
     "repositories": [
         {
             "type": "composer",
             "url": "https://repo.magento.com/"
         }
     ],
-    "require": {
-        "php": "^8.1",
-        "magento/framework": ">=103.0.4",
-        "magento/module-store": "*",
-        "willdurand/geocoder": "^4.4"
-    },
-    "require-dev": {
-        "smile/magento2-smilelab-quality-suite": "^3.0"
-    },
-    "license": "OSL-3.0",
-    "authors": [
-        {
-            "name": "Aurélien FOUCRET",
-            "email": "aurelien.foucret@smile.fr"
-        },
-        {
-            "name": "Romain Ruaud",
-            "email": "romain.ruaud@smile.fr"
-        },
-        {
-            "name": "Guillaume Vrac",
-            "email": "guillaume.vrac@smile.fr"
-        }
-    ],
+    "minimum-stability": "dev",
+    "prefer-stable": true,
     "autoload": {
         "files": [
             "registration.php"
         ],
         "psr-4": {
-            "Smile\\Map\\" : ""
+            "Smile\\Map\\": ""
         }
     },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "config": {
+        "allow-plugins": {
+            "magento/composer-dependency-version-audit-plugin": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "sort-packages": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "magento/framework": "*",
         "magento/module-store": "*",
-        "willdurand/geocoder": "^3.3"
+        "willdurand/geocoder": "^3.3 || ^4.4"
     },
     "require-dev": {
         "smile/magento2-smilelab-quality-suite": "1.0.0"

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Smile_Map ACLs.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Romain Ruaud <romain.ruaud@smile.fr>
- * @copyright 2017 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
- -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Acl/etc/acl.xsd">
     <acl>
         <resources>
@@ -23,7 +6,7 @@
                 <resource id="Magento_Backend::stores">
                     <resource id="Magento_Backend::stores_settings">
                         <resource id="Magento_Config::config">
-                            <resource id="Magento_Backend::smile_map" title="Manage Smile Map settings" />
+                            <resource id="Magento_Backend::smile_map" title="Manage Smile Map settings"/>
                         </resource>
                     </resource>
                 </resource>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Smile_Map admin configuration UI fields.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Romain Ruaud <romain.ruaud@smile.fr>
- * @copyright 2017 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
- -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -1,26 +1,10 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Smile Map Configuration.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
--->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Store:etc/config.xsd">
     <default>
         <smile_map>
             <map>
                 <provider>osm</provider>
-                
+
                 <provider_osm_tile_url>https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png</provider_osm_tile_url>
                 <provider_osm_direction_url_template>https://www.openstreetmap.org/directions?route={{depend has_origin}}{{var orig_latitude}},{{var orig_longitude}}{{/depend}};{{var dest_latitude}},{{var dest_longitude}}</provider_osm_direction_url_template>
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,42 +1,24 @@
 <?xml version="1.0"?>
-<!--
-/**
- * Smile Map Dependency Injection.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Apache License Version 2.0
- */
--->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+    <preference for="Smile\Map\Api\Data\GeoPointInterface" type="Smile\Map\Model\GeoPoint"/>
+    <preference for="Smile\Map\Api\Data\AddressInterface" type="Smile\Map\Model\Address"/>
+    <preference for="Smile\Map\Api\Data\GeolocalizedAddressInterface" type="Smile\Map\Model\GeolocalizedAddress"/>
+    <preference for="Smile\Map\Api\MapProviderInterface" type="Smile\Map\Model\MapProvider"/>
 
-    <preference for="Smile\Map\Api\Data\GeoPointInterface" type="Smile\Map\Model\GeoPoint" />
-    <preference for="Smile\Map\Api\Data\AddressInterface" type="Smile\Map\Model\Address" />
-    <preference for="Smile\Map\Api\Data\GeolocalizedAddressInterface" type="Smile\Map\Model\GeolocalizedAddress" />
-    
-    <preference for="Smile\Map\Api\MapProviderInterface" type="Smile\Map\Model\MapProvider" />
-    
     <virtualType name="Smile\Map\Model\Map\Osm" type="Smile\Map\Model\Map\DefaultMap">
         <arguments>
             <argument name="identifier" xsi:type="string">osm</argument>
             <argument name="name" xsi:type="string">OpenStreetMap</argument>
         </arguments>
     </virtualType>
-    
+
     <virtualType name="Smile\Map\Model\Map\Google" type="Smile\Map\Model\Map\DefaultMap">
         <arguments>
             <argument name="identifier" xsi:type="string">google</argument>
             <argument name="name" xsi:type="string">Google Maps</argument>
         </arguments>
     </virtualType>
-    
+
     <type name="Smile\Map\Model\MapProvider">
         <arguments>
             <argument name="mapProviders" xsi:type="array">

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,19 +1,4 @@
 <?xml version="1.0"?>
-<!--
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Romain Ruaud <romain.ruaud@smile.fr>
- * @author    Aurelien FOUCRET <aurelien.foucret@smile.fr>
- * @copyright 2016 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
--->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Smile_Map" setup_version="1.0.0">
         <sequence>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="extensions" value="php,phtml"/>
+    <arg name="colors"/>
+
+    <!-- Show progress of the run -->
+    <arg value="p"/>
+
+    <!-- Show sniff codes -->
+    <arg value="s"/>
+
+    <config name="php_version" value="80100"/>
+
+    <rule ref="SmileLab">
+        <!-- Ignored rules due to legacy code -->
+        <exclude name="Magento2.Exceptions.DirectThrow.FoundDirectThrow"/>
+        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing"/>
+    </rule>
+
+    <file>.</file>
+    <exclude-pattern>vendor/*</exclude-pattern>
+</ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,7 +17,6 @@
     <rule ref="SmileLab">
         <!-- Ignored rules due to legacy code -->
         <exclude name="Magento2.Exceptions.DirectThrow.FoundDirectThrow"/>
-        <exclude name="SlevomatCodingStandard.TypeHints.DeclareStrictTypes.DeclareStrictTypesMissing"/>
     </rule>
 
     <file>.</file>

--- a/phpmd.xml.dist
+++ b/phpmd.xml.dist
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding="UTF-8"?>
+<ruleset xmlns="http://pmd.sf.net/ruleset/1.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sf.net/ruleset/1.0.0 http://pmd.sf.net/ruleset_xml_schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://pmd.sf.net/ruleset_xml_schema.xsd">
+
+    <rule ref="vendor/smile/magento2-smilelab-phpmd/ruleset.xml"/>
+
+    <exclude-pattern>vendor/*</exclude-pattern>
+</ruleset>

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,11 @@
+parameters:
+    level: 6
+    phpVersion: 80100
+    checkMissingIterableValueType: false
+    paths:
+        - .
+    excludePaths:
+        - 'vendor/*'
+
+includes:
+    - %currentWorkingDirectory%/vendor/smile/magento2-smilelab-phpstan/extension.neon

--- a/registration.php
+++ b/registration.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Magento\Framework\Component\ComponentRegistrar;
 
 ComponentRegistrar::register(

--- a/registration.php
+++ b/registration.php
@@ -1,19 +1,9 @@
 <?php
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Aurelien FOUCRET <aurelien.foucret@gmail.com>
- * @copyright 2016 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
 
-\Magento\Framework\Component\ComponentRegistrar::register(
-    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+use Magento\Framework\Component\ComponentRegistrar;
+
+ComponentRegistrar::register(
+    ComponentRegistrar::MODULE,
     'Smile_Map',
     __DIR__
 );

--- a/view/frontend/layout/smile_map_styles.xml
+++ b/view/frontend/layout/smile_map_styles.xml
@@ -1,27 +1,10 @@
 <?xml version="1.0"?>
-<!--
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- *
- * @category  Smile
- * @package   Smile\StoreLocator
- * @author    Romain Ruaud <romain.ruaud@smile.fr>
- * @author    Guillaume Vrac <guillaume.vrac@smile.fr>
- * @copyright 2016 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
- -->
 <page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="Smile_Map::leaflet/leaflet.css"/>
-        <!-- add conditional load css when use markercluser mode -->
+        <!-- Add conditional load css when use markercluser mode -->
         <css src="Smile_Map::leaflet/plugins/markercluster/MarkerCluster.css"/>
         <css src="Smile_Map::leaflet/plugins/markercluster/MarkerCluster.Default.css"/>
         <script src="Smile_Map::js/polyfill/ie11/promise.min.js" ie_condition="IE 11"/>
     </head>
 </page>
-

--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -1,18 +1,3 @@
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Romain Ruaud <romain.ruaud@smile.fr>
- * @author    Guillaume Vrac <guillaume.vrac@smile.fr>
- * @copyright 2016 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
-
 var config = {
     map: {
         '*': {

--- a/view/frontend/web/js/geocoder.js
+++ b/view/frontend/web/js/geocoder.js
@@ -1,17 +1,3 @@
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Romain Ruaud <romain.ruaud@smile.fr>
- * @copyright 2017 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
-/*global define*/
 define([
     'jquery',
     'uiComponent',

--- a/view/frontend/web/js/listItemEvent.js
+++ b/view/frontend/web/js/listItemEvent.js
@@ -1,17 +1,3 @@
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Ihor KVASNYTSKYI <ihor.kvasnytskyi@smile-ukraine.com>
- * @copyright 2019 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
-/*global define*/
 define([
     'jquery',
     'smile-map'
@@ -20,7 +6,7 @@ define([
     $.widget('smile.listItemEvent', {
 
         _create: function () {
-            
+
             this.element.on('mouseover', function () {
                 this.removeCurrentClass();
                 this.showCurrentMarker();

--- a/view/frontend/web/js/mapMobile.js
+++ b/view/frontend/web/js/mapMobile.js
@@ -1,17 +1,3 @@
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Ihor KVASNYTSKYI <ihor.kvasnytskyi@smile-ukraine.com>
- * @copyright 2019 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
-/*global define*/
 define([
     'jquery',
     'smile-map'

--- a/view/frontend/web/js/model/geoAddress.js
+++ b/view/frontend/web/js/model/geoAddress.js
@@ -1,17 +1,3 @@
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Remy LESCALLIER <remy.lescallier@smile.fr>
- * @copyright 2020 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
-
 define(function () {
     'use strict';
 

--- a/view/frontend/web/js/model/markers.js
+++ b/view/frontend/web/js/model/markers.js
@@ -1,17 +1,3 @@
-/**
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade this module to newer
- * versions in the future.
- *
- *
- * @category  Smile
- * @package   Smile\Map
- * @author    Romain Ruaud <romain.ruaud@smile.fr>
- * @copyright 2017 Smile
- * @license   Open Software License ("OSL") v. 3.0
- */
-/*global define*/
 define(['ko', 'uiClass'], function(ko, Class) {
     "use strict";
 


### PR DESCRIPTION
Dataset compatibility ES 2.11.x and PHP 8.2

- fix Dynamic type declaration
- fix Type hinting
- Replace `Zend_Date` by `DateTime`
- Remove `MutationObserver` support
- fix UI Component Retailer Offer editing
- Replace `Zend_Validate` by `Laminas\Validator`
- fix Retailer Grid Column Action
- fix Retailer Grid Mass Actions
- fix some translations
- remove Temando/Shipping Plugin